### PR TITLE
Loosen abseil version requirement for Python 3.8 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
     ],
     namespace_packages=[],
     install_requires=[
-        'absl-py>=0.7,<0.9',
+        'absl-py>=0.7,<0.10',
         'googleapis-common-protos',
         'protobuf>=3.7,<4',
     ],


### PR DESCRIPTION
Abseil < 0.9 isn't compatible with Python 3.8. This PR loosens the version requirements since it would break compatibility with Python 3.8 and reintroduce https://github.com/tensorflow/tensorflow/issues/35027

It looks like abseil is only used for testing (b338be67d97cd186d7ebb2c4034d714c7954d534), so alternatively this dependency could be removed entirely and only added to the test dependencies.

/cc @mihaimaruseac