### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -125,7 +125,7 @@ setup(
     ],
     namespace_packages=[],
     install_requires=[
-        'absl-py>=0.9,<0.13',
+        'absl-py>=0.9',
         'googleapis-common-protos>=1.52.0,<2',
         'protobuf>=3.13,<4',
     ],


### PR DESCRIPTION
How can the version be >=0.9 AND <0.13? Is it a typo here? I had an error exactly here while installing and I propose this fix. But if I misunderstood please let me know.