### PR TITLE
Ci build

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -25,22 +25,6 @@ jobs:
     - name: install python dependencies
       run: pip install build twine
 
-    - uses: bazel-contrib/setup-bazel@0.14.0
-      name: Set up Bazel
-      with:
-        # Avoid downloading Bazel every time.
-        bazelisk-cache: true
-        # Store build cache per workflow.
-        disk-cache: ${{ github.workflow }}-${{ hashFiles('.github/workflows/wheels.yml') }}
-        # Share repository cache between workflows.
-        repository-cache: true
-
-    - name: Verify bazel installation
-      run: |
-        which bazel
-        bazel info
-        bazel version
-
     - name: build sdist
       run: |
         python -m build --sdist -o wheelhouse

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   USE_BAZEL_VERSION: "7.6.1"
- 
+
 
 jobs:
   build:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -16,9 +16,9 @@ jobs:
       build ${{ matrix.python-version }} on ${{ matrix.platform || matrix.os }}
       ${{ (matrix.arch) || '' }}
     strategy:
-      fail-fast: false
+      # fail-fast: true
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu]
         python-version: ['3.9', '3.10', '3.11', '3.12']
 
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,0 +1,150 @@
+name: Build Wheels & Publish to PyPI
+
+on:
+  pull_request:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+env:
+  USE_BAZEL_VERSION: "7.2.1"
+
+jobs:
+  build_sdist:
+    name: Build sdist
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out the repo
+      uses: actions/checkout@v4
+
+    - name: Set up python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+
+    - name: install python dependencies
+      run: pip install build twine
+
+    - uses: bazel-contrib/setup-bazel@0.14.0
+      name: Set up Bazel
+      with:
+        # Avoid downloading Bazel every time.
+        bazelisk-cache: true
+        # Store build cache per workflow.
+        disk-cache: ${{ github.workflow }}-${{ hashFiles('.github/workflows/wheels.yml') }}
+        # Share repository cache between workflows.
+        repository-cache: true
+
+    - name: Verify bazel installation
+      run: |
+        which bazel
+        bazel info
+        bazel version
+
+    - name: build sdist
+      run: |
+        python -m build --sdist -o wheelhouse
+
+    - name: List and check sdist
+      run: |
+        ls -lh wheelhouse/
+        twine check wheelhouse/*
+
+    - name: Upload sdist
+      uses: actions/upload-artifact@v4
+      with:
+        name: sdist
+        path: ./wheelhouse/*.tar.gz
+
+  build_wheels:
+    name: >
+      build ${{ matrix.python-version }} on ${{ matrix.platform || matrix.os }}
+      ${{ (matrix.arch) || '' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu]
+        python-version: ['cp311']
+
+    runs-on: ${{ format('{0}-latest', matrix.os) }}
+    steps:
+    - name: Check out the repo
+      uses: actions/checkout@v4
+
+    - name: Set up python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+
+    - name: Install python build dependencies
+      run: |
+
+          pip install wheel
+          
+
+    - uses: bazel-contrib/setup-bazel@0.14.0
+      name: Set up Bazel
+      with:
+        # Avoid downloading Bazel every time.
+        bazelisk-cache: true
+        # Store build cache per workflow.
+        disk-cache: ${{ github.workflow }}-${{ hashFiles('.github/workflows/wheels.yml') }}
+        # Share repository cache between workflows.
+        repository-cache: true
+
+    - name: Verify bazel installation
+      run: |
+        which bazel
+        bazel info
+        bazel version
+
+    - name: Install build
+      run: python -m pip install --upgrade pip build
+
+    - name: Build wheels
+      run: |
+        python -m build --wheel
+        mkdir wheelhouse
+        mv dist/*.whl wheelhouse/
+
+    - name: List and check wheels
+      run: |
+        pip install twine pkginfo>=1.11.0
+        ${{ matrix.ls || 'ls -lh' }} wheelhouse/
+        twine check wheelhouse/*
+
+    - name: Upload wheels
+      uses: actions/upload-artifact@v4
+      with:
+        name: wheels-${{ matrix.python-version }}-${{ matrix.os }}
+        path: ./wheelhouse/*.whl
+
+  upload_to_pypi:
+    name: Upload to PyPI
+    runs-on: ubuntu-latest
+    if: (github.event_name == 'release' && startsWith(github.ref, 'refs/tags')) || (github.event_name == 'workflow_dispatch')
+    needs: [build_wheels, build_sdist]
+    environment:
+      name: pypi
+      url: https://pypi.org/p/tensorflow-metadata
+    permissions:
+      id-token: write
+    steps:
+      - name: Retrieve wheels and sdist
+        uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
+          path: wheels/
+
+      - name: List the build artifacts
+        run: |
+          ls -lAs wheels/
+
+      - name: Upload to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1.12
+        with:
+          packages-dir: wheels/
+          repository-url: https://pypi.org/legacy/
+          # already checked, and the pkginfo/twine versions on this runner causes check to fail
+          verify-metadata: false
+          verbose: true

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -44,7 +44,7 @@ jobs:
 
     - name: Build wheels
       run: |
-        python -m build
+        python -m build --wheel --sdist
         mkdir wheelhouse
         mv dist/*.whl wheelhouse/
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -64,22 +64,6 @@ jobs:
       run: |
           pip install wheel
 
-    - uses: bazel-contrib/setup-bazel@0.14.0
-      name: Set up Bazel
-      with:
-        # Avoid downloading Bazel every time.
-        bazelisk-cache: true
-        # Store build cache per workflow.
-        disk-cache: ${{ github.workflow }}-${{ hashFiles('.github/workflows/wheels.yml') }}
-        # Share repository cache between workflows.
-        repository-cache: true
-
-    - name: Verify bazel installation
-      run: |
-        which bazel
-        bazel info
-        bazel version
-
     - name: Install build
       run: python -m pip install --upgrade pip build
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Upload wheels
       uses: actions/upload-artifact@v4
       with:
-        name: wheels-${{ matrix.python-version }}-${{ matrix.os }}
+        name: build-${{ matrix.python-version }}-${{ matrix.os }}
         path: ./wheelhouse/*
 
   upload_to_pypi:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -37,6 +37,12 @@ jobs:
     - name: Install build
       run: python -m pip install --upgrade pip build
 
+    - name: Verify bazel installation
+      run: |
+        which bazel
+        bazel info
+        bazel version
+
     - name: Build wheels
       run: |
         python -m build

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -10,37 +10,7 @@ env:
   USE_BAZEL_VERSION: "7.2.1"
 
 jobs:
-  build_sdist:
-    name: Build sdist
-    runs-on: ubuntu-latest
-    steps:
-    - name: Check out the repo
-      uses: actions/checkout@v4
-
-    - name: Set up python
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.11'
-
-    - name: install python dependencies
-      run: pip install build twine
-
-    - name: build sdist
-      run: |
-        python -m build --sdist -o wheelhouse
-
-    - name: List and check sdist
-      run: |
-        ls -lh wheelhouse/
-        twine check wheelhouse/*
-
-    - name: Upload sdist
-      uses: actions/upload-artifact@v4
-      with:
-        name: sdist
-        path: ./wheelhouse/*.tar.gz
-
-  build_wheels:
+  build:
     name: >
       build ${{ matrix.python-version }} on ${{ matrix.platform || matrix.os }}
       ${{ (matrix.arch) || '' }}
@@ -69,7 +39,7 @@ jobs:
 
     - name: Build wheels
       run: |
-        python -m build --wheel
+        python -m build
         mkdir wheelhouse
         mv dist/*.whl wheelhouse/
 
@@ -89,7 +59,7 @@ jobs:
     name: Upload to PyPI
     runs-on: ubuntu-latest
     if: (github.event_name == 'release' && startsWith(github.ref, 'refs/tags')) || (github.event_name == 'workflow_dispatch')
-    needs: [build_wheels, build_sdist]
+    needs: [build]
     environment:
       name: pypi
       url: https://pypi.org/p/tensorflow-metadata

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -62,9 +62,7 @@ jobs:
 
     - name: Install python build dependencies
       run: |
-
           pip install wheel
-          
 
     - uses: bazel-contrib/setup-bazel@0.14.0
       name: Set up Bazel

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -7,7 +7,8 @@ on:
     types: [published]
 
 env:
-  USE_BAZEL_VERSION: "7.2.1"
+  # USE_BAZEL_VERSION: "7.2.1"
+  USE_BAZEL_VERSION: "6.5.0"
 
 jobs:
   build:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -36,17 +36,11 @@ jobs:
       run: |
           python -m pip install --upgrade pip build
 
-    - name: Verify bazel installation
-      run: |
-        which bazel
-        bazel info
-        bazel version
-
     - name: Build wheels
       run: |
         python -m build --wheel --sdist
         mkdir wheelhouse
-        mv dist/*.whl wheelhouse/
+        mv dist/* wheelhouse/
 
     - name: List and check wheels
       run: |
@@ -58,7 +52,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: wheels-${{ matrix.python-version }}-${{ matrix.os }}
-        path: ./wheelhouse/*.whl
+        path: ./wheelhouse/*
 
   upload_to_pypi:
     name: Upload to PyPI

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -7,8 +7,8 @@ on:
     types: [published]
 
 env:
-  # USE_BAZEL_VERSION: "7.2.1"
-  USE_BAZEL_VERSION: "6.5.0"
+  USE_BAZEL_VERSION: "7.6.1"
+ 
 
 jobs:
   build:
@@ -18,8 +18,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu]
-        python-version: ['cp311']
+        os: [ubuntu-latest]
+        python-version: ['3.9', '3.10', '3.11', '3.12']
+
 
     runs-on: ${{ format('{0}-latest', matrix.os) }}
     steps:
@@ -29,14 +30,11 @@ jobs:
     - name: Set up python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
+        python-version: ${{ matrix.python-version }}
 
     - name: Install python build dependencies
       run: |
-          pip install wheel
-
-    - name: Install build
-      run: python -m pip install --upgrade pip build
+          python -m pip install --upgrade pip build
 
     - name: Verify bazel installation
       run: |


### PR DESCRIPTION
Adds a CI workflow for building wheel and pushing metadata to pypi. Note that for this to work, the tensorflow/metadata repo will need to be setup as a [trusted publisher](https://docs.pypi.org/trusted-publishers/) on the relevant pypi account. 

I tested this workflow with the testpypi artifactory. You can see the results [here](https://github.com/andrewfulton9/metadata/actions/runs/14888887725) of the CI run here.